### PR TITLE
refactor getChapterAssignment route handler

### DIFF
--- a/src/domains/chapter-assignments/chapter-assignments.repository.ts
+++ b/src/domains/chapter-assignments/chapter-assignments.repository.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 
 import type { DbTransaction, Result, USJDocument } from '@/lib/types';
 import type { VerseData } from '@/lib/usfm-converter';
@@ -12,6 +12,7 @@ import {
   chapter_assignment_status_history,
   chapter_assignments,
   project_units,
+  project_users,
   projects,
   translated_verses,
 } from '@/db/schema';
@@ -27,6 +28,12 @@ import type {
   CreateChapterAssignmentRequestData,
   UpdateChapterAssignmentRequestData,
 } from './chapter-assignments.types';
+
+export interface ChapterAssignmentWithAuthContext extends ChapterAssignmentRecord {
+  projectId: number;
+  organizationId: number;
+  isProjectMember: boolean;
+}
 
 const USJ_SPEC_VERSION = '0.0.1';
 
@@ -70,6 +77,55 @@ export async function findByIdWithOrg(id: number): Promise<Result<ChapterAssignm
     return ok(assignment);
   } catch (e) {
     logger.error({ cause: e, message: 'Failed to fetch chapter assignment', context: { id } });
+    return err(ErrorCode.INTERNAL_ERROR);
+  }
+}
+
+export async function findByIdWithAuthContext(
+  id: number,
+  userId: number,
+  roleName: string
+): Promise<Result<ChapterAssignmentWithAuthContext>> {
+  try {
+    const [assignment] = await db
+      .select({
+        // Assignment fields
+        id: chapter_assignments.id,
+        projectUnitId: chapter_assignments.projectUnitId,
+        bibleId: chapter_assignments.bibleId,
+        bookId: chapter_assignments.bookId,
+        chapterNumber: chapter_assignments.chapterNumber,
+        assignedUserId: chapter_assignments.assignedUserId,
+        peerCheckerId: chapter_assignments.peerCheckerId,
+        status: chapter_assignments.status,
+        submittedTime: chapter_assignments.submittedTime,
+        createdAt: chapter_assignments.createdAt,
+        updatedAt: chapter_assignments.updatedAt,
+        // Project context
+        projectId: projects.id,
+        organizationId: projects.organization,
+        // Project membership (LEFT JOIN to handle non-members)
+        isProjectMember: sql<boolean>`CASE WHEN ${project_users.userId} IS NOT NULL THEN true ELSE false END`,
+      })
+      .from(chapter_assignments)
+      .innerJoin(project_units, eq(chapter_assignments.projectUnitId, project_units.id))
+      .innerJoin(projects, eq(project_units.projectId, projects.id))
+      .leftJoin(
+        project_users,
+        and(
+          eq(project_users.projectId, projects.id),
+          eq(project_users.userId, userId),
+          // Only check membership for translators (per resolveIsProjectMember logic)
+          roleName === 'translator' ? sql`1=1` : sql`1=0`
+        )
+      )
+      .where(eq(chapter_assignments.id, id))
+      .limit(1);
+
+    if (!assignment) return err(ErrorCode.CHAPTER_ASSIGNMENT_NOT_FOUND);
+    return ok(assignment);
+  } catch (e) {
+    logger.error({ cause: e, message: 'Failed to fetch chapter assignment with auth context', context: { id, userId } });
     return err(ErrorCode.INTERNAL_ERROR);
   }
 }

--- a/src/domains/chapter-assignments/chapter-assignments.route.ts
+++ b/src/domains/chapter-assignments/chapter-assignments.route.ts
@@ -14,7 +14,6 @@ import { server } from '@/server/server';
 
 import { ChapterAssignmentPolicy } from './chapter-assignments.policy';
 import * as chapterAssignmentService from './chapter-assignments.service';
-import { toChapterAssignmentResponse } from './chapter-assignments.service';
 import { chapterAssignmentResponseSchema } from './chapter-assignments.types';
 
 const chapterAssignmentIdParam = z.object({
@@ -274,42 +273,17 @@ const getChapterAssignmentRoute = createRoute({
 server.openapi(getChapterAssignmentRoute, async (c) => {
   const { chapterAssignmentId } = c.req.valid('param');
   const currentUser = c.get('user')!;
-  const policyUser = {
-    id: currentUser.id,
-    role: currentUser.role,
-    roleName: currentUser.roleName,
-    organization: currentUser.organization,
-  };
 
-  const result = await chapterAssignmentService.getChapterAssignment(chapterAssignmentId);
+  const result = await chapterAssignmentService.getChapterAssignmentWithAuth(
+    chapterAssignmentId,
+    currentUser
+  );
+
   if (!result.ok) {
     return c.json({ message: result.error.message }, getHttpStatus(result.error) as never);
   }
 
-  const unitResult = await projectHandler.getProjectIdByUnitId(result.data.projectUnitId);
-  if (!unitResult.ok) {
-    return c.json({ message: 'Chapter assignment not found' }, HttpStatusCodes.NOT_FOUND);
-  }
-
-  const projectResult = await projectHandler.getProjectById(unitResult.data.projectId);
-  if (!projectResult.ok) {
-    return c.json({ message: 'Chapter assignment not found' }, HttpStatusCodes.NOT_FOUND);
-  }
-
-  const isProjectMember = await resolveIsProjectMember(
-    unitResult.data.projectId,
-    currentUser.id,
-    currentUser.roleName
-  );
-
-  if (!ProjectPolicy.read(policyUser, projectResult.data, isProjectMember)) {
-    return c.json(
-      { message: 'Forbidden: You do not have permission to view this assignment.' },
-      HttpStatusCodes.FORBIDDEN
-    );
-  }
-
-  return c.json(toChapterAssignmentResponse(result.data), HttpStatusCodes.OK);
+  return c.json(result.data, HttpStatusCodes.OK);
 });
 
 // ─── DELETE /chapter-assignments/:chapterAssignmentId ────────────────────────

--- a/src/domains/chapter-assignments/chapter-assignments.service.ts
+++ b/src/domains/chapter-assignments/chapter-assignments.service.ts
@@ -4,6 +4,10 @@ import { db } from '@/db';
 import { logger } from '@/lib/logger';
 import { err, ErrorCode, ok } from '@/lib/types';
 
+import { resolveIsProjectMember } from '@/domains/projects/project-users/project-users.handlers';
+import { ProjectPolicy } from '@/domains/projects/project.policy';
+import * as projectHandler from '@/domains/projects/projects.handlers';
+
 import type { PolicyChapterAssignment } from './chapter-assignments.policy';
 import type {
   ChapterAssignmentRecord,
@@ -36,6 +40,51 @@ export function toChapterAssignmentResponse(
 
 export function getChapterAssignment(id: number): Promise<Result<ChapterAssignmentRecordWithOrg>> {
   return repo.findByIdWithOrg(id);
+}
+
+export async function getChapterAssignmentWithAuth(
+  chapterAssignmentId: number,
+  currentUser: {
+    id: number;
+    role: number;
+    roleName: string;
+    organization: number;
+  }
+): Promise<Result<ChapterAssignmentResponse>> {
+  // Get assignment with auth context in single query
+  const assignmentResult = await repo.findByIdWithAuthContext(
+    chapterAssignmentId,
+    currentUser.id,
+    currentUser.roleName
+  );
+  if (!assignmentResult.ok) {
+    return assignmentResult;
+  }
+
+  const assignment = assignmentResult.data;
+  const policyUser = {
+    id: currentUser.id,
+    role: currentUser.role,
+    roleName: currentUser.roleName,
+    organization: currentUser.organization,
+  };
+
+  // Get project data for policy check (still using existing handlers)
+  const projectResult = await projectHandler.getProjectById(assignment.projectId);
+  if (!projectResult.ok) {
+    return err(ErrorCode.CHAPTER_ASSIGNMENT_NOT_FOUND); // Consistent with current behavior
+  }
+
+  // Authorization check - moved from route handler
+  const isProjectMember = currentUser.roleName === 'translator' 
+    ? assignment.isProjectMember 
+    : await resolveIsProjectMember(assignment.projectId, currentUser.id, currentUser.roleName);
+
+  if (!ProjectPolicy.read(policyUser, projectResult.data, isProjectMember)) {
+    return err(ErrorCode.FORBIDDEN);
+  }
+
+  return ok(toChapterAssignmentResponse(assignment));
 }
 
 export function getAssignmentForVerse(


### PR DESCRIPTION
- Add findByIdWithAuthContext repository method with joined query
- Add getChapterAssignmentWithAuth service method with authorization logic
- Simplify route handler to focus on HTTP concerns only
- Reduce database queries from 4 to 2 (50% improvement)
- Move authorization logic from route to service layer
- Maintain compatibility with existing project handlers and error patterns