### PR TITLE
Adding project ID to response for mobile sync

### DIFF
--- a/src/domains/users/chapter-assignments/users-chapter-assignments.repository.ts
+++ b/src/domains/users/chapter-assignments/users-chapter-assignments.repository.ts
@@ -24,6 +24,7 @@ const sourceLang = alias(languages, 'source_lang');
 
 interface QueryRow {
   assignmentId: number;
+  projectId: number;
   projectName: string;
   projectUnitId: number;
   bibleId: number;
@@ -47,6 +48,7 @@ function createBaseQuery() {
   return db
     .select({
       assignmentId: chapter_assignments.id,
+      projectId: projects.id,
       projectName: projects.name,
       projectUnitId: chapter_assignments.projectUnitId,
       bibleId: chapter_assignments.bibleId,
@@ -97,6 +99,7 @@ function createBaseQuery() {
       chapter_assignments.assignedUserId,
       chapter_assignments.peerCheckerId,
       chapter_assignments.updatedAt,
+      projects.id,
       projects.name,
       bibles.name,
       languages.langName,
@@ -110,6 +113,7 @@ function createBaseQuery() {
 function mapRows(rows: QueryRow[]): UserChapterAssignment[] {
   return rows.map((row) => ({
     chapterAssignmentId: row.assignmentId,
+    projectId: row.projectId,
     projectName: row.projectName,
     projectUnitId: row.projectUnitId,
     bibleId: row.bibleId,

--- a/src/domains/users/chapter-assignments/users-chapter-assignments.service.ts
+++ b/src/domains/users/chapter-assignments/users-chapter-assignments.service.ts
@@ -20,6 +20,7 @@ import * as repo from './users-chapter-assignments.repository';
 export function toResponse(assignment: UserChapterAssignment): UserChapterAssignmentResponse {
   return {
     chapterAssignmentId: assignment.chapterAssignmentId,
+    projectId: assignment.projectId,
     projectName: assignment.projectName,
     projectUnitId: assignment.projectUnitId,
     bibleId: assignment.bibleId,

--- a/src/domains/users/chapter-assignments/users-chapter-assignments.types.ts
+++ b/src/domains/users/chapter-assignments/users-chapter-assignments.types.ts
@@ -3,6 +3,7 @@ import { z } from '@hono/zod-openapi';
 // ─── DB-derived types ─────────────────────────────────────────────────────────
 export interface UserChapterAssignment {
   chapterAssignmentId: number;
+  projectId: number;
   projectName: string;
   projectUnitId: number;
   bibleId: number;
@@ -25,6 +26,7 @@ export interface UserChapterAssignment {
 // ─── API response schema ──────────────────────────────────────────────────────
 export const userChapterAssignmentResponseSchema = z.object({
   chapterAssignmentId: z.number().int(),
+  projectId: z.number().int(),
   projectName: z.string(),
   projectUnitId: z.number().int(),
   bibleId: z.number().int(),


### PR DESCRIPTION
- #112
- The project Unit table in mobile relies on the response from the chapter assignment api. since it had only project name but project unit ID,  thought of adding the project ID as well as to make everythign seamless