### PR TITLE
Changes regarding the mobile integration

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,13 @@
+NODE_ENV=test
+PORT=9999
+LOG_LEVEL=silent
+DATABASE_URL=postgres://test-user:test-password@localhost:5432/test-db
+BETTER_AUTH_SECRET=test-only-dummy-secret-not-used-in-production
+BETTER_AUTH_URL=http://localhost:9999/api/auth
+BETTER_AUTH_COOKIE_DOMAIN=localhost
+BETTER_AUTH_SESSION_EXPIRY_SECONDS=604800
+APPLICATIONINSIGHTS_CONNECTION_STRING=test-only-dummy-connection-string
+EMAIL_SERVICE_API_KEY=test-only-dummy-api-key
+EMAIL_SERVICE_DOMAIN=test.example.com
+EMAIL_SERVICE_SENDER=no-reply@test.example.com
+FRONTEND_URL=http://localhost:5173

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ web_modules/
 .env.local
 *.env.*
 !.env.example
+!.env.test
 
 # logs
 logs/

--- a/docs/authentication-migration.md
+++ b/docs/authentication-migration.md
@@ -92,3 +92,188 @@ BetterAuth uses a specific salted hashing format. Standard `bcrypt` hashes gener
 ### Invitations
 
 The system supports magic links for invitations. This can be triggered via the `magicLink` plugin in the backend `src/lib/auth.ts`.
+
+---
+
+## Mobile Client Integration
+
+This section is for developers building the Fluent mobile app (React Native / Axios). It documents the exact contract between the mobile client and the server's authentication layer.
+
+### Mobile Identity Headers (Sign-In Only)
+
+Mobile clients must send the following two headers **only on the sign-in request**:
+
+| Header          | Required value  | Notes                        |
+| --------------- | --------------- | ---------------------------- |
+| `x-client-type` | `mobile`        | Exact string, case-sensitive |
+| `user-agent`    | `fluent-mobile` | Case-insensitive             |
+
+These headers are checked **once** at sign-in. The server uses them to stamp the session as `isMobile = true` in the database. All subsequent API calls do not need these headers — the server identifies the session as mobile from the database flag, not from request headers.
+
+> **Legacy fallback**: Older builds that only send a `user-agent` containing the substring `fluentmobile` (no hyphen, case-insensitive) will also be recognised. This means `FluentMobile` (as referenced in the mobile issue) also works — `FluentMobile` → lowercase → `fluentmobile` → matched by the fallback. New builds should always use the strict two-header approach above.
+
+### Sign-In Flow
+
+**Endpoint**: `POST /api/auth/sign-in/email`
+
+**Request**:
+
+```http
+POST /api/auth/sign-in/email
+Content-Type: application/json
+x-client-type: mobile
+User-Agent: fluent-mobile
+
+{
+  "email": "user@example.com",
+  "password": "secret"
+}
+```
+
+**Response** (200):
+
+The server returns the session token in two places:
+
+1. **`set-auth-token` response header** (recommended — this is what the issue uses):
+
+   ```
+   set-auth-token: <url-encoded-session-token>
+   ```
+
+   > **Important**: The token in this header is URL-encoded by BetterAuth. Always call `decodeURIComponent()` on it before storing or using it.
+
+2. **JSON body `token` field** (alternative):
+   ```json
+   {
+     "token": "<session-token>",
+     "session": "<session-object>",
+     "user": "<user-object>"
+   }
+   ```
+
+**Recommended extraction** (React Native / Axios):
+
+```ts
+const response = await axios.post('/api/auth/sign-in/email', body, { headers });
+// From response header (URL-encoded — must decode):
+const encoded = response.headers['set-auth-token'];
+const token = encoded ? decodeURIComponent(encoded) : response.data.token;
+await Keychain.setGenericPassword('session', token, { service: 'fluent_session' });
+```
+
+### Authenticating Subsequent Requests
+
+Pass the stored token in the `Authorization` header on every API call. **No mobile-specific headers are needed here** — the server identifies the session as mobile from the database:
+
+```http
+GET /api/languages
+Authorization: Bearer <session-token>
+```
+
+> The server uses the Bearer token to validate the session. Cookies are **not** used for mobile — do not send or store cookies.
+
+### Session Lifecycle
+
+| Property                 | Value                                                                                         |
+| ------------------------ | --------------------------------------------------------------------------------------------- |
+| Initial session lifetime | 60 days from sign-in                                                                          |
+| Rolling window           | If fewer than 30 days remain, the server automatically extends the session by another 60 days |
+| Rolling check frequency  | At most once every 24 hours per session (server-side, transparent to the client)              |
+| Inactivity expiry        | A session that goes untouched for 60 days will expire                                         |
+
+The rolling extension is entirely server-side and transparent — the client does not need to do anything. As long as the user opens the app at least once every 30 days, they will stay logged in indefinitely.
+
+### Error Handling
+
+When a Bearer token is present but the session is invalid, the server returns a structured 401 with a specific message. The mobile app should act on the message to show the right UI:
+
+| HTTP Status | `message` field                      | Meaning                                      | Recommended action                       |
+| ----------- | ------------------------------------ | -------------------------------------------- | ---------------------------------------- |
+| `401`       | `"Session token has expired"`        | Token existed but its expiry date has passed | Show re-login screen                     |
+| `401`       | `"Invalid or revoked session token"` | Token not found or explicitly revoked        | Clear stored token, show re-login screen |
+
+**Example error response**:
+
+```json
+{
+  "message": "Session token has expired"
+}
+```
+
+### Sign-Out
+
+**Endpoint**: `POST /api/auth/sign-out`
+
+```http
+POST /api/auth/sign-out
+Authorization: Bearer <session-token>
+x-client-type: mobile
+User-Agent: fluent-mobile
+```
+
+On success (200), delete the stored token from local storage.
+
+### Password Reset (Forgot Password)
+
+**Endpoint**: `POST /api/auth/forget-password`
+
+```http
+POST /api/auth/forget-password
+Content-Type: application/json
+x-client-type: mobile
+User-Agent: fluent-mobile
+
+{
+  "email": "user@example.com"
+}
+```
+
+The server will send a password reset email. No Bearer token is required for this endpoint.
+
+### Axios Interceptor Example
+
+Configure a base Axios instance that attaches the Bearer token on every call, and handles 401s globally. The mobile identity headers (`x-client-type`, `User-Agent`) only need to be sent on the sign-in request itself:
+
+```ts
+import axios from 'axios';
+
+// Base client for all API calls — only needs the Bearer token
+export const apiClient = axios.create({
+  baseURL: 'https://api.yourdomain.com',
+});
+
+// Attach token from storage before each request
+apiClient.interceptors.request.use((config) => {
+  const token = getStoredToken(); // your local storage helper
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// Handle 401s globally
+apiClient.interceptors.response.use(
+  (res) => res,
+  (error) => {
+    if (error.response?.status === 401) {
+      clearStoredToken();
+      navigateToLogin();
+    }
+    return Promise.reject(error);
+  }
+);
+
+// Sign-in call — mobile identity headers required here only
+export function signIn(email: string, password: string) {
+  return apiClient.post(
+    '/api/auth/sign-in/email',
+    { email, password },
+    {
+      headers: {
+        'x-client-type': 'mobile',
+        'User-Agent': 'fluent-mobile',
+      },
+    }
+  );
+}
+```

--- a/src/db/migrations/0011_add_is_mobile_to_auth_session.sql
+++ b/src/db/migrations/0011_add_is_mobile_to_auth_session.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "auth_session" ADD COLUMN "is_mobile" boolean DEFAULT false NOT NULL;

--- a/src/db/migrations/meta/0011_snapshot.json
+++ b/src/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,2289 @@
+{
+  "id": "f6a47766-9387-4565-93c4-9237d431a0e4",
+  "prevId": "215ac9fb-e170-4975-9f11-77b471673625",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_chapter_editors": {
+      "name": "active_chapter_editors",
+      "schema": "",
+      "columns": {
+        "chapter_assignment_id": {
+          "name": "chapter_assignment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_active_editors_chapter": {
+          "name": "idx_active_editors_chapter",
+          "columns": [
+            {
+              "expression": "chapter_assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "active_chapter_editors_chapter_assignment_id_chapter_assignments_id_fk": {
+          "name": "active_chapter_editors_chapter_assignment_id_chapter_assignments_id_fk",
+          "tableFrom": "active_chapter_editors",
+          "tableTo": "chapter_assignments",
+          "columnsFrom": ["chapter_assignment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "active_chapter_editors_user_id_users_id_fk": {
+          "name": "active_chapter_editors_user_id_users_id_fk",
+          "tableFrom": "active_chapter_editors",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "active_chapter_editors_chapter_assignment_id_user_id_pk": {
+          "name": "active_chapter_editors_chapter_assignment_id_user_id_pk",
+          "columns": ["chapter_assignment_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_audit_log": {
+      "name": "auth_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_user": {
+          "name": "idx_audit_log_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_event": {
+          "name": "idx_audit_log_event",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_created": {
+          "name": "idx_audit_log_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_audit_log_user_id_auth_user_id_fk": {
+          "name": "auth_audit_log_user_id_auth_user_id_fk",
+          "tableFrom": "auth_audit_log",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_mobile": {
+          "name": "is_mobile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_session_token_unique": {
+          "name": "auth_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_user_email_unique": {
+          "name": "auth_user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bible_books": {
+      "name": "bible_books",
+      "schema": "",
+      "columns": {
+        "bible_id": {
+          "name": "bible_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bible_books_bible_id_bibles_id_fk": {
+          "name": "bible_books_bible_id_bibles_id_fk",
+          "tableFrom": "bible_books",
+          "tableTo": "bibles",
+          "columnsFrom": ["bible_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bible_books_book_id_books_id_fk": {
+          "name": "bible_books_book_id_books_id_fk",
+          "tableFrom": "bible_books",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bible_texts": {
+      "name": "bible_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bible_id": {
+          "name": "bible_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_number": {
+          "name": "chapter_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_number": {
+          "name": "verse_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bible_texts_bible_book_chapter": {
+          "name": "idx_bible_texts_bible_book_chapter",
+          "columns": [
+            {
+              "expression": "bible_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bible_texts_bible_book_chapter_verse": {
+          "name": "idx_bible_texts_bible_book_chapter_verse",
+          "columns": [
+            {
+              "expression": "bible_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bible_texts_bible_id_bibles_id_fk": {
+          "name": "bible_texts_bible_id_bibles_id_fk",
+          "tableFrom": "bible_texts",
+          "tableTo": "bibles",
+          "columnsFrom": ["bible_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bible_texts_book_id_books_id_fk": {
+          "name": "bible_texts_book_id_books_id_fk",
+          "tableFrom": "bible_texts",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bibles": {
+      "name": "bibles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bibles_language_id_languages_id_fk": {
+          "name": "bibles_language_id_languages_id_fk",
+          "tableFrom": "bibles",
+          "tableTo": "languages",
+          "columnsFrom": ["language_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bibles_name_unique": {
+          "name": "bibles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        },
+        "bibles_abbreviation_unique": {
+          "name": "bibles_abbreviation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["abbreviation"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eng_display_name": {
+          "name": "eng_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapter_assignment_assigned_user_history": {
+      "name": "chapter_assignment_assigned_user_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chapter_assignment_id": {
+          "name": "chapter_assignment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_user_id": {
+          "name": "assigned_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "assignment_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "chapter_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ca_user_history_assignment": {
+          "name": "idx_ca_user_history_assignment",
+          "columns": [
+            {
+              "expression": "chapter_assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ca_user_history_user": {
+          "name": "idx_ca_user_history_user",
+          "columns": [
+            {
+              "expression": "assigned_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapter_assignment_assigned_user_history_chapter_assignment_id_chapter_assignments_id_fk": {
+          "name": "chapter_assignment_assigned_user_history_chapter_assignment_id_chapter_assignments_id_fk",
+          "tableFrom": "chapter_assignment_assigned_user_history",
+          "tableTo": "chapter_assignments",
+          "columnsFrom": ["chapter_assignment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chapter_assignment_assigned_user_history_assigned_user_id_users_id_fk": {
+          "name": "chapter_assignment_assigned_user_history_assigned_user_id_users_id_fk",
+          "tableFrom": "chapter_assignment_assigned_user_history",
+          "tableTo": "users",
+          "columnsFrom": ["assigned_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapter_assignment_snapshots": {
+      "name": "chapter_assignment_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chapter_assignment_id": {
+          "name": "chapter_assignment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "chapter_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_user_id": {
+          "name": "assigned_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ca_snapshots_assignment": {
+          "name": "idx_ca_snapshots_assignment",
+          "columns": [
+            {
+              "expression": "chapter_assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ca_snapshots_user": {
+          "name": "idx_ca_snapshots_user",
+          "columns": [
+            {
+              "expression": "assigned_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapter_assignment_snapshots_chapter_assignment_id_chapter_assignments_id_fk": {
+          "name": "chapter_assignment_snapshots_chapter_assignment_id_chapter_assignments_id_fk",
+          "tableFrom": "chapter_assignment_snapshots",
+          "tableTo": "chapter_assignments",
+          "columnsFrom": ["chapter_assignment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chapter_assignment_snapshots_assigned_user_id_users_id_fk": {
+          "name": "chapter_assignment_snapshots_assigned_user_id_users_id_fk",
+          "tableFrom": "chapter_assignment_snapshots",
+          "tableTo": "users",
+          "columnsFrom": ["assigned_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapter_assignment_status_history": {
+      "name": "chapter_assignment_status_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chapter_assignment_id": {
+          "name": "chapter_assignment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "chapter_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ca_status_history_assignment": {
+          "name": "idx_ca_status_history_assignment",
+          "columns": [
+            {
+              "expression": "chapter_assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapter_assignment_status_history_chapter_assignment_id_chapter_assignments_id_fk": {
+          "name": "chapter_assignment_status_history_chapter_assignment_id_chapter_assignments_id_fk",
+          "tableFrom": "chapter_assignment_status_history",
+          "tableTo": "chapter_assignments",
+          "columnsFrom": ["chapter_assignment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapter_assignments": {
+      "name": "chapter_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_unit_id": {
+          "name": "project_unit_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bible_id": {
+          "name": "bible_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_number": {
+          "name": "chapter_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_user_id": {
+          "name": "assigned_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "peer_checker_id": {
+          "name": "peer_checker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_status": {
+          "name": "chapter_status",
+          "type": "chapter_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "submitted_time": {
+          "name": "submitted_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_chapter_assignment_per_chapter": {
+          "name": "uq_chapter_assignment_per_chapter",
+          "columns": [
+            {
+              "expression": "project_unit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bible_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chapter_assignments_assigned_user": {
+          "name": "idx_chapter_assignments_assigned_user",
+          "columns": [
+            {
+              "expression": "assigned_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chapter_assignments_peer_checker_status": {
+          "name": "idx_chapter_assignments_peer_checker_status",
+          "columns": [
+            {
+              "expression": "peer_checker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chapter_assignments_project_unit": {
+          "name": "idx_chapter_assignments_project_unit",
+          "columns": [
+            {
+              "expression": "project_unit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapter_assignments_project_unit_id_project_units_id_fk": {
+          "name": "chapter_assignments_project_unit_id_project_units_id_fk",
+          "tableFrom": "chapter_assignments",
+          "tableTo": "project_units",
+          "columnsFrom": ["project_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "chapter_assignments_bible_id_bibles_id_fk": {
+          "name": "chapter_assignments_bible_id_bibles_id_fk",
+          "tableFrom": "chapter_assignments",
+          "tableTo": "bibles",
+          "columnsFrom": ["bible_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chapter_assignments_book_id_books_id_fk": {
+          "name": "chapter_assignments_book_id_books_id_fk",
+          "tableFrom": "chapter_assignments",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chapter_assignments_assigned_user_id_users_id_fk": {
+          "name": "chapter_assignments_assigned_user_id_users_id_fk",
+          "tableFrom": "chapter_assignments",
+          "tableTo": "users",
+          "columnsFrom": ["assigned_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chapter_assignments_peer_checker_id_users_id_fk": {
+          "name": "chapter_assignments_peer_checker_id_users_id_fk",
+          "tableFrom": "chapter_assignments",
+          "tableTo": "users",
+          "columnsFrom": ["peer_checker_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lang_name": {
+          "name": "lang_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lang_name_localized": {
+          "name": "lang_name_localized",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lang_code_iso_639_3": {
+          "name": "lang_code_iso_639_3",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_direction": {
+          "name": "script_direction",
+          "type": "script_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ltr'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_name_unique": {
+          "name": "organizations_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_unit_bible_books": {
+      "name": "project_unit_bible_books",
+      "schema": "",
+      "columns": {
+        "project_unit_id": {
+          "name": "project_unit_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bible_id": {
+          "name": "bible_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_unit_bible_books_project_unit_id_project_units_id_fk": {
+          "name": "project_unit_bible_books_project_unit_id_project_units_id_fk",
+          "tableFrom": "project_unit_bible_books",
+          "tableTo": "project_units",
+          "columnsFrom": ["project_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "project_unit_bible_books_bible_id_bibles_id_fk": {
+          "name": "project_unit_bible_books_bible_id_bibles_id_fk",
+          "tableFrom": "project_unit_bible_books",
+          "tableTo": "bibles",
+          "columnsFrom": ["bible_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "project_unit_bible_books_book_id_books_id_fk": {
+          "name": "project_unit_bible_books_book_id_books_id_fk",
+          "tableFrom": "project_unit_bible_books",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_units": {
+      "name": "project_units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "project_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_units_project_id_projects_id_fk": {
+          "name": "project_units_project_id_projects_id_fk",
+          "tableFrom": "project_units",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_users": {
+      "name": "project_users",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_users_project": {
+          "name": "idx_project_users_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_users_user": {
+          "name": "idx_project_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_users_project_id_projects_id_fk": {
+          "name": "project_users_project_id_projects_id_fk",
+          "tableFrom": "project_users",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "project_users_user_id_users_id_fk": {
+          "name": "project_users_user_id_users_id_fk",
+          "tableFrom": "project_users",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_users_project_id_user_id_pk": {
+          "name": "project_users_project_id_user_id_pk",
+          "columns": ["project_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_language": {
+          "name": "source_language",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization": {
+          "name": "organization",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "project_assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_assigned'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_source_language_languages_id_fk": {
+          "name": "projects_source_language_languages_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "languages",
+          "columnsFrom": ["source_language"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "projects_target_language_languages_id_fk": {
+          "name": "projects_target_language_languages_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "languages",
+          "columnsFrom": ["target_language"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "projects_organization_organizations_id_fk": {
+          "name": "projects_organization_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_role_permissions_role": {
+          "name": "idx_role_permissions_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": ["permission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "name": "role_permissions_role_id_permission_id_pk",
+          "columns": ["role_id", "permission_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translated_verses": {
+      "name": "translated_verses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_unit_id": {
+          "name": "project_unit_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bible_text_id": {
+          "name": "bible_text_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_user_id": {
+          "name": "assigned_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_translated_verse_per_bible_text": {
+          "name": "uq_translated_verse_per_bible_text",
+          "columns": [
+            {
+              "expression": "project_unit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bible_text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translated_verses_project_unit_id_project_units_id_fk": {
+          "name": "translated_verses_project_unit_id_project_units_id_fk",
+          "tableFrom": "translated_verses",
+          "tableTo": "project_units",
+          "columnsFrom": ["project_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "translated_verses_bible_text_id_bible_texts_id_fk": {
+          "name": "translated_verses_bible_text_id_bible_texts_id_fk",
+          "tableFrom": "translated_verses",
+          "tableTo": "bible_texts",
+          "columnsFrom": ["bible_text_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "translated_verses_assigned_user_id_users_id_fk": {
+          "name": "translated_verses_assigned_user_id_users_id_fk",
+          "tableFrom": "translated_verses",
+          "tableTo": "users",
+          "columnsFrom": ["assigned_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_chapter_assignment_editor_state": {
+      "name": "user_chapter_assignment_editor_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_assignment_id": {
+          "name": "chapter_assignment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resources": {
+          "name": "resources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_user_chapter_assignment_editor_state": {
+          "name": "uq_user_chapter_assignment_editor_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_chapter_assignment_editor_state_user_id_users_id_fk": {
+          "name": "user_chapter_assignment_editor_state_user_id_users_id_fk",
+          "tableFrom": "user_chapter_assignment_editor_state",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_chapter_assignment_editor_state_chapter_assignment_id_chapter_assignments_id_fk": {
+          "name": "user_chapter_assignment_editor_state_chapter_assignment_id_chapter_assignments_id_fk",
+          "tableFrom": "user_chapter_assignment_editor_state",
+          "tableTo": "chapter_assignments",
+          "columnsFrom": ["chapter_assignment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization": {
+          "name": "organization",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invited'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_auth_user_id_auth_user_id_fk": {
+          "name": "users_auth_user_id_auth_user_id_fk",
+          "tableFrom": "users",
+          "tableTo": "auth_user",
+          "columnsFrom": ["auth_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_role_roles_id_fk": {
+          "name": "users_role_roles_id_fk",
+          "tableFrom": "users",
+          "tableTo": "roles",
+          "columnsFrom": ["role"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_organization_organizations_id_fk": {
+          "name": "users_organization_organizations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_created_by_users_id_fk": {
+          "name": "users_created_by_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.assignment_role": {
+      "name": "assignment_role",
+      "schema": "public",
+      "values": ["drafter", "peer_checker"]
+    },
+    "public.chapter_status": {
+      "name": "chapter_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "draft",
+        "peer_check",
+        "community_review",
+        "linguist_check",
+        "theological_check",
+        "consultant_check",
+        "complete"
+      ]
+    },
+    "public.project_assignment_status": {
+      "name": "project_assignment_status",
+      "schema": "public",
+      "values": ["active", "not_assigned"]
+    },
+    "public.project_status": {
+      "name": "project_status",
+      "schema": "public",
+      "values": ["not_started", "in_progress", "completed"]
+    },
+    "public.script_direction": {
+      "name": "script_direction",
+      "schema": "public",
+      "values": ["ltr", "rtl"]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": ["invited", "verified", "inactive"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1778225352600,
       "tag": "0010_add_better_auth",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1779441453059,
+      "tag": "0011_add_is_mobile_to_auth_session",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -83,6 +83,9 @@ export const authSession = pgTable('auth_session', {
     .references(() => authUser.id, { onDelete: 'cascade' }),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  // Durably flags mobile sessions at sign-in time.
+  // Avoids per-request UA re-parsing for rolling logic.
+  isMobile: boolean('is_mobile').notNull().default(false),
 });
 
 export const authAccount = pgTable('auth_account', {

--- a/src/domains/users/users.service.ts
+++ b/src/domains/users/users.service.ts
@@ -2,7 +2,13 @@ import type { Result } from '@/lib/types';
 
 import { ok } from '@/lib/types';
 
-import type { CreateUserInput, UpdateUserInput, User, UserResponse } from './users.types';
+import type {
+  CreateUserInput,
+  CreateUserWithAuthInput,
+  UpdateUserInput,
+  User,
+  UserResponse,
+} from './users.types';
 
 import * as repo from './users.repository';
 
@@ -75,6 +81,14 @@ export async function getUserByEmailOrUsername(identifier: string): Promise<Resu
 // ─── Writes ───────────────────────────────────────────────────────────────────
 
 export async function createUser(input: CreateUserInput): Promise<Result<UserResponse>> {
+  const result = await repo.insert(input);
+  if (!result.ok) return result;
+  return ok(toUserResponse(result.data));
+}
+
+export async function createUserWithAuth(
+  input: CreateUserWithAuthInput
+): Promise<Result<UserResponse>> {
   const result = await repo.insert(input);
   if (!result.ok) return result;
   return ok(toUserResponse(result.data));

--- a/src/domains/users/users.types.ts
+++ b/src/domains/users/users.types.ts
@@ -8,6 +8,8 @@ export type User = z.infer<typeof selectUsersSchema>;
 export type CreateUserInput = z.infer<typeof insertUsersSchema>;
 export type UpdateUserInput = z.infer<typeof patchUsersSchema>;
 
+export type CreateUserWithAuthInput = CreateUserInput & { authUserId: string };
+
 // Used by findByEmail — joined with roles table to support policy checks
 export type UserWithRole = User & { roleName: string };
 

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { auth } from './auth';
+
+// ─── Module Mocks ────────────────────────────────────────────────────────────
+
+// We mock the database and schema
+const { mockDbUpdate } = vi.hoisted(() => ({
+  mockDbUpdate: vi.fn(),
+}));
+
+vi.mock('@/db', () => ({
+  db: {
+    update: mockDbUpdate,
+  },
+}));
+
+vi.mock('@/db/schema', () => ({
+  authUser: { id: 'id', name: 'name', email: 'email' },
+  authSession: {
+    id: 'id',
+    expiresAt: 'expires_at',
+    isMobile: 'is_mobile',
+    token: 'token',
+  },
+  authAccount: { id: 'id' },
+  authVerification: { id: 'id' },
+  authAuditLog: { id: 'id' },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('betterAuth configuration - hooks.after', () => {
+  let mockUpdateChain: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateChain = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDbUpdate.mockReturnValue(mockUpdateChain);
+  });
+
+  // Extract the hook from options — the first test guards it is defined before other tests run.
+  const hook = auth.options?.hooks?.after as (ctx: any) => Promise<void>;
+
+  it('should have the hook defined', () => {
+    expect(hook).toBeDefined();
+    expect(typeof hook).toBe('function');
+  });
+
+  it('should skip if path is not /sign-in/email', async () => {
+    const ctx: any = {
+      path: '/sign-up/email',
+      context: {
+        newSession: {
+          session: { id: 'session-123' },
+        },
+      },
+      headers: new Headers({ 'x-client-type': 'mobile' }),
+    };
+
+    await hook(ctx);
+
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('should skip if there is no newSession', async () => {
+    const ctx: any = {
+      path: '/sign-in/email',
+      context: {},
+      headers: new Headers({ 'x-client-type': 'mobile' }),
+    };
+
+    await hook(ctx);
+
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('should skip if request does not have mobile headers/UA', async () => {
+    const ctx: any = {
+      path: '/sign-in/email',
+      context: {
+        newSession: {
+          session: { id: 'session-123' },
+        },
+      },
+      headers: new Headers({ 'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)' }),
+    };
+
+    await hook(ctx);
+
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('should skip if only x-client-type: mobile is sent (missing user-agent: fluent-mobile)', async () => {
+    const ctx: any = {
+      path: '/sign-in/email',
+      context: {
+        newSession: {
+          session: { id: 'session-123' },
+        },
+      },
+      // x-client-type alone is not sufficient — must also have user-agent: fluent-mobile
+      headers: new Headers({ 'x-client-type': 'mobile' }),
+    };
+
+    await hook(ctx);
+
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('should extend session to 60 days and set isMobile=true when both x-client-type: mobile AND user-agent: fluent-mobile are present', async () => {
+    const ctx: any = {
+      path: '/sign-in/email',
+      context: {
+        newSession: {
+          session: { id: 'session-123' },
+        },
+      },
+      headers: new Headers({ 'x-client-type': 'mobile', 'user-agent': 'fluent-mobile' }),
+    };
+
+    const beforeHookTime = Date.now();
+    await hook(ctx);
+    const afterHookTime = Date.now();
+
+    expect(mockDbUpdate).toHaveBeenCalled();
+    expect(mockUpdateChain.set).toHaveBeenCalled();
+
+    // Retrieve the update values passed to .set()
+    const setArgs = mockUpdateChain.set.mock.calls[0][0];
+    expect(setArgs.isMobile).toBe(true);
+    expect(setArgs.expiresAt).toBeInstanceOf(Date);
+
+    // Check that expiresAt is approximately 60 days in the future
+    const expectedTime = beforeHookTime + 60 * 24 * 60 * 60 * 1000;
+    const actualTime = setArgs.expiresAt.getTime();
+    expect(actualTime).toBeGreaterThanOrEqual(expectedTime);
+    expect(actualTime).toBeLessThanOrEqual(afterHookTime + 60 * 24 * 60 * 60 * 1000);
+  });
+
+  it('should extend session to 60 days and set isMobile=true when UA contains fluentmobile', async () => {
+    const ctx: any = {
+      path: '/sign-in/email',
+      context: {
+        newSession: {
+          session: { id: 'session-123' },
+        },
+      },
+      headers: new Headers({ 'user-agent': 'some-app-fluentmobile-client/1.0' }),
+    };
+
+    await hook(ctx);
+
+    expect(mockDbUpdate).toHaveBeenCalled();
+    const setArgs = mockUpdateChain.set.mock.calls[0][0];
+    expect(setArgs.isMobile).toBe(true);
+  });
+});

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -145,22 +145,4 @@ describe('betterAuth configuration - hooks.after', () => {
     expect(actualTime).toBeGreaterThanOrEqual(expectedTime);
     expect(actualTime).toBeLessThanOrEqual(afterHookTime + 60 * 24 * 60 * 60 * 1000);
   });
-
-  it('should extend session to 60 days and set isMobile=true when UA contains fluentmobile', async () => {
-    const ctx: any = {
-      path: '/sign-in/email',
-      context: {
-        newSession: {
-          session: { id: 'session-123' },
-        },
-      },
-      headers: new Headers({ 'user-agent': 'some-app-fluentmobile-client/1.0' }),
-    };
-
-    await hook(ctx);
-
-    expect(mockDbUpdate).toHaveBeenCalled();
-    const setArgs = mockUpdateChain.set.mock.calls[0][0];
-    expect(setArgs.isMobile).toBe(true);
-  });
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,14 +1,35 @@
 import { drizzleAdapter } from '@better-auth/drizzle-adapter';
 import { passkey } from '@better-auth/passkey';
 import { betterAuth } from 'better-auth';
+import { createAuthMiddleware } from 'better-auth/api';
 import { bearer, magicLink, twoFactor } from 'better-auth/plugins';
 import { admin } from 'better-auth/plugins/admin';
+import { eq } from 'drizzle-orm';
 
 import { db } from '@/db';
 import * as schema from '@/db/schema';
 import env from '@/env';
 import { logger } from '@/lib/logger';
 import { sendEmail } from '@/lib/services/notifications/mailgun.service';
+
+const MOBILE_SESSION_DAYS = 60;
+const MOBILE_SESSION_MS = MOBILE_SESSION_DAYS * 24 * 60 * 60 * 1000;
+
+function isMobileRequest(headers?: Headers | null): boolean {
+  if (!headers || typeof headers.get !== 'function') return false;
+  const clientType = headers.get('x-client-type');
+  const ua = (headers.get('user-agent') ?? '').toLowerCase();
+  if (clientType === 'mobile' && ua === 'fluent-mobile') return true;
+  return ua.includes('fluentmobile');
+}
+
+function getWebOrigin(frontendUrl: string): string {
+  try {
+    return new URL(frontendUrl).origin;
+  } catch {
+    return frontendUrl.replace(/\/$/, '');
+  }
+}
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
@@ -23,7 +44,15 @@ export const auth = betterAuth({
   }),
   baseURL: env.BETTER_AUTH_URL,
   secret: env.BETTER_AUTH_SECRET,
-  trustedOrigins: [env.FRONTEND_URL],
+
+  trustedOrigins: (_request?: Request) => {
+    const webOrigin = getWebOrigin(env.FRONTEND_URL);
+    const origins = [webOrigin];
+    if (env.NODE_ENV === 'production') {
+      origins.push('https://*.fluent.bible');
+    }
+    return origins;
+  },
 
   // ─── Email/Password ─────────────────────────────────────────────
   emailAndPassword: {
@@ -142,6 +171,35 @@ export const auth = betterAuth({
     // Bearer tokens (for mobile clients)
     bearer(),
   ],
+
+  // ─── Hooks ───────────────────────────────────────────────────────
+  // After a successful email sign-in, extend the session to 60 days
+  // and stamp isMobile=true for Fluent mobile clients.
+  hooks: {
+    after: createAuthMiddleware(async (ctx) => {
+      if (!ctx.path.startsWith('/sign-in')) return;
+
+      const newSession = ctx.context.newSession;
+      if (!newSession) return;
+
+      if (!isMobileRequest(ctx.headers as Headers)) return;
+
+      const expiresAt = new Date(Date.now() + MOBILE_SESSION_MS);
+
+      try {
+        await db
+          .update(schema.authSession)
+          .set({ expiresAt, isMobile: true })
+          .where(eq(schema.authSession.id, newSession.session.id));
+
+        logger.info('Mobile session created: lifetime extended to 60 days', {
+          sessionId: newSession.session.id,
+        });
+      } catch (error) {
+        logger.error('Failed to extend mobile session lifetime', { error });
+      }
+    }),
+  },
 
   // ─── Audit Logging via databaseHooks ─────────────────────────────
   databaseHooks: {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -19,8 +19,7 @@ function isMobileRequest(headers?: Headers | null): boolean {
   if (!headers || typeof headers.get !== 'function') return false;
   const clientType = headers.get('x-client-type');
   const ua = (headers.get('user-agent') ?? '').toLowerCase();
-  if (clientType === 'mobile' && ua === 'fluent-mobile') return true;
-  return ua.includes('fluentmobile');
+  return clientType === 'mobile' && ua === 'fluent-mobile';
 }
 
 function getWebOrigin(frontendUrl: string): string {

--- a/src/lib/services/auth/auth.service.ts
+++ b/src/lib/services/auth/auth.service.ts
@@ -63,7 +63,7 @@ export async function createUserWithInvitation(
   try {
     // 3. Send magic link invitation via BetterAuth
     // BetterAuth REQUIRES headers to be passed for security context
-    await auth.api.signInMagicLink({
+    await (auth.api as any).signInMagicLink({
       body: {
         email: normalizedInput.email,
         callbackURL: `${env.FRONTEND_URL}/accept-invitation`,

--- a/src/lib/services/auth/auth.service.ts
+++ b/src/lib/services/auth/auth.service.ts
@@ -6,7 +6,7 @@ import type { Result } from '@/lib/types';
 
 import { db } from '@/db';
 import * as schema from '@/db/schema';
-import { createUser, deleteUser } from '@/domains/users/users.service';
+import { createUserWithAuth, deleteUser } from '@/domains/users/users.service';
 import env from '@/env';
 import { auth } from '@/lib/auth';
 import { ErrorCode } from '@/lib/types';
@@ -49,10 +49,10 @@ export async function createUserWithInvitation(
   }
 
   // 2. Create user in local database
-  const dbResult = await createUser({
+  const dbResult = await createUserWithAuth({
     ...normalizedInput,
     authUserId,
-  } as any);
+  });
 
   if (!dbResult.ok) {
     // Rollback BetterAuth identity if local DB creation fails
@@ -61,9 +61,9 @@ export async function createUserWithInvitation(
   }
 
   try {
-    // 3. Send magic link invitation via BetterAuth
-    // BetterAuth REQUIRES headers to be passed for security context
-    await (auth.api as any).signInMagicLink({
+    // 3. Send magic link invitation via BetterAuth.
+    type AuthAPI = typeof auth;
+    await (auth as AuthAPI).api.signInMagicLink({
       body: {
         email: normalizedInput.email,
         callbackURL: `${env.FRONTEND_URL}/accept-invitation`,

--- a/src/middlewares/authenticate.test.ts
+++ b/src/middlewares/authenticate.test.ts
@@ -6,6 +6,8 @@ import { ok } from '@/lib/types';
 
 import { authenticate } from './authenticate';
 
+// ─── Module mocks ────────────────────────────────────────────────────────────
+
 vi.mock('@/lib/auth', () => ({
   auth: {
     api: {
@@ -26,6 +28,74 @@ vi.mock('@/lib/logger', () => ({
   },
 }));
 
+// vi.mock factories are hoisted by Vitest — any variables they close over must
+// also be hoisted using vi.hoisted(), otherwise "Cannot access before initialization".
+const { mockDbSelect, mockDbUpdate } = vi.hoisted(() => ({
+  mockDbSelect: vi.fn(),
+  mockDbUpdate: vi.fn(),
+}));
+
+vi.mock('@/db', () => ({
+  db: {
+    select: mockDbSelect,
+    update: mockDbUpdate,
+  },
+}));
+
+vi.mock('@/db/schema', () => ({
+  authSession: {
+    token: 'token',
+    id: 'id',
+    expiresAt: 'expires_at',
+    isMobile: 'is_mobile',
+  },
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildSelectChain(rows: object[]) {
+  const chain = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  };
+  mockDbSelect.mockReturnValue(chain);
+  return chain;
+}
+
+function buildUpdateChain() {
+  const chain = {
+    set: vi.fn().mockReturnThis(),
+    where: vi.fn().mockResolvedValue(undefined),
+  };
+  mockDbUpdate.mockReturnValue(chain);
+  return chain;
+}
+
+const THIRTY_ONE_DAYS_MS = 31 * 24 * 60 * 60 * 1000;
+const TWENTY_NINE_DAYS_MS = 29 * 24 * 60 * 60 * 1000;
+const TWENTY_FIVE_HOURS_MS = 25 * 60 * 60 * 1000;
+
+function makeMockSession(
+  overrides: {
+    updatedAtMsAgo?: number;
+    expiresInMs?: number;
+  } = {}
+) {
+  const updatedAt = new Date(Date.now() - (overrides.updatedAtMsAgo ?? TWENTY_FIVE_HOURS_MS));
+  const expiresAt = new Date(Date.now() + (overrides.expiresInMs ?? THIRTY_ONE_DAYS_MS));
+  return {
+    user: { email: 'test@example.com' },
+    session: {
+      id: 'session-id-123',
+      updatedAt,
+      expiresAt,
+    },
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
 describe('authenticate middleware', () => {
   let mockContext: any;
   let next: any;
@@ -35,14 +105,15 @@ describe('authenticate middleware', () => {
     mockContext = {
       req: {
         path: '/api/some-domain',
-        raw: {
-          headers: new Headers(),
-        },
+        raw: { headers: new Headers() },
+        header: vi.fn().mockReturnValue(undefined),
       },
       set: vi.fn(),
     };
     next = vi.fn().mockResolvedValue(undefined);
   });
+
+  // ── Passthrough cases ────────────────────────────────────────────────────
 
   it('should skip authentication for /api/auth routes', async () => {
     mockContext.req.path = '/api/auth/sign-in';
@@ -51,20 +122,162 @@ describe('authenticate middleware', () => {
     expect(auth.api.getSession).not.toHaveBeenCalled();
   });
 
-  it('should call next() if no session is found', async () => {
+  it('should call next() silently if no session and no Bearer token', async () => {
     (auth.api.getSession as any).mockResolvedValue(null);
+    mockContext.req.header.mockReturnValue(undefined);
+
     await authenticate(mockContext, next);
-    expect(auth.api.getSession).toHaveBeenCalled();
+
+    expect(next).toHaveBeenCalled();
     expect(mockContext.set).not.toHaveBeenCalled();
+    // No DB lookup should happen without a Bearer token
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  // ── Granular Bearer token error cases ───────────────────────────────────
+
+  it('bearer token present + token not in DB → 401 "Invalid or revoked session token"', async () => {
+    (auth.api.getSession as any).mockResolvedValue(null);
+    mockContext.req.header.mockReturnValue('Bearer invalid-token-xyz');
+
+    buildSelectChain([]); // empty result = token not in DB
+
+    await expect(authenticate(mockContext, next)).rejects.toMatchObject({
+      status: 401,
+      message: 'Invalid or revoked session token',
+    });
+
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('bearer token present + token found but expired → 401 "Session token has expired"', async () => {
+    (auth.api.getSession as any).mockResolvedValue(null);
+    mockContext.req.header.mockReturnValue('Bearer expired-token-xyz');
+
+    // Token IS in the DB (getSession rejected it = BetterAuth considers it expired)
+    buildSelectChain([{ expiresAt: new Date(Date.now() - 1000) }]);
+
+    await expect(authenticate(mockContext, next)).rejects.toMatchObject({
+      status: 401,
+      message: 'Session token has expired',
+    });
+
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('bearer token present + token found and not expired but getSession returned null → 401 "Invalid or revoked session token"', async () => {
+    (auth.api.getSession as any).mockResolvedValue(null);
+    mockContext.req.header.mockReturnValue('Bearer revoked-token-xyz');
+
+    // Token is in DB and has future expiresAt, but getSession still failed (e.g. user deleted)
+    buildSelectChain([{ expiresAt: new Date(Date.now() + 100000) }]);
+
+    await expect(authenticate(mockContext, next)).rejects.toMatchObject({
+      status: 401,
+      message: 'Invalid or revoked session token',
+    });
+
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('bearer token present + getSession() returns valid session → passes through, no 401', async () => {
+    const mockSession = makeMockSession({ expiresInMs: THIRTY_ONE_DAYS_MS });
+    (auth.api.getSession as any).mockResolvedValue(mockSession);
+    (getUserByEmail as any).mockResolvedValue(ok({ id: 1, email: 'test@example.com' }));
+    mockContext.req.header.mockReturnValue('Bearer valid-token-xyz');
+
+    // DB check for rolling: non-mobile session
+    buildSelectChain([{ isMobile: false, expiresAt: new Date(Date.now() + THIRTY_ONE_DAYS_MS) }]);
+
+    await authenticate(mockContext, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(mockContext.set).toHaveBeenCalledWith('session', mockSession);
+  });
+
+  // ── Mobile session rolling cases ─────────────────────────────────────────
+
+  it('mobile session with < 30 days remaining → rolls expiry by 60 days', async () => {
+    const mockSession = makeMockSession({
+      updatedAtMsAgo: TWENTY_FIVE_HOURS_MS, // stale: older than 24h → will check DB
+      expiresInMs: TWENTY_NINE_DAYS_MS, // < 30 days remaining → should roll
+    });
+    (auth.api.getSession as any).mockResolvedValue(mockSession);
+    (getUserByEmail as any).mockResolvedValue(ok({ id: 1, email: 'test@example.com' }));
+    mockContext.req.header.mockReturnValue(undefined);
+
+    buildSelectChain([{ isMobile: true, expiresAt: new Date(Date.now() + TWENTY_NINE_DAYS_MS) }]);
+    const updateChain = buildUpdateChain();
+
+    await authenticate(mockContext, next);
+
+    expect(mockDbUpdate).toHaveBeenCalled();
+    expect(updateChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expiresAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      })
+    );
     expect(next).toHaveBeenCalled();
   });
 
-  it('should set user and session in context if valid session and user exist', async () => {
-    const mockSession = { user: { email: 'test@example.com' } };
-    const mockUser = { id: 1, email: 'test@example.com' };
+  it('mobile session with > 30 days remaining → does NOT roll expiry', async () => {
+    const mockSession = makeMockSession({
+      updatedAtMsAgo: TWENTY_FIVE_HOURS_MS, // stale: will check DB
+      expiresInMs: THIRTY_ONE_DAYS_MS, // > 30 days → no roll needed
+    });
+    (auth.api.getSession as any).mockResolvedValue(mockSession);
+    (getUserByEmail as any).mockResolvedValue(ok({ id: 1, email: 'test@example.com' }));
+    mockContext.req.header.mockReturnValue(undefined);
 
+    buildSelectChain([{ isMobile: true, expiresAt: new Date(Date.now() + THIRTY_ONE_DAYS_MS) }]);
+
+    await authenticate(mockContext, next);
+
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('non-mobile session → no DB rolling check performed', async () => {
+    const mockSession = makeMockSession({ updatedAtMsAgo: TWENTY_FIVE_HOURS_MS });
+    (auth.api.getSession as any).mockResolvedValue(mockSession);
+    (getUserByEmail as any).mockResolvedValue(ok({ id: 1, email: 'test@example.com' }));
+    mockContext.req.header.mockReturnValue(undefined);
+
+    buildSelectChain([{ isMobile: false, expiresAt: new Date(Date.now() + THIRTY_ONE_DAYS_MS) }]);
+
+    await authenticate(mockContext, next);
+
+    // DB is read for the check (updatedAt is stale), but no update
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('fresh mobile session (updatedAt < 24h ago) → skips DB check entirely', async () => {
+    const mockSession = makeMockSession({
+      updatedAtMsAgo: 30 * 60 * 1000, // 30 minutes ago = fresh
+      expiresInMs: TWENTY_NINE_DAYS_MS,
+    });
+    (auth.api.getSession as any).mockResolvedValue(mockSession);
+    (getUserByEmail as any).mockResolvedValue(ok({ id: 1, email: 'test@example.com' }));
+    mockContext.req.header.mockReturnValue(undefined);
+
+    await authenticate(mockContext, next);
+
+    // updatedAt is fresh — no DB select or update should happen
+    expect(mockDbSelect).not.toHaveBeenCalled();
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  // ── User lookup cases ────────────────────────────────────────────────────
+
+  it('should set user and session in context if valid session and user exist', async () => {
+    const mockSession = makeMockSession({ updatedAtMsAgo: 30 * 60 * 1000 });
+    const mockUser = { id: 1, email: 'test@example.com' };
     (auth.api.getSession as any).mockResolvedValue(mockSession);
     (getUserByEmail as any).mockResolvedValue(ok(mockUser));
+    mockContext.req.header.mockReturnValue(undefined);
 
     await authenticate(mockContext, next);
 
@@ -73,11 +286,11 @@ describe('authenticate middleware', () => {
     expect(next).toHaveBeenCalled();
   });
 
-  it('should set only session if user is not found in database', async () => {
-    const mockSession = { user: { email: 'test@example.com' } };
-
+  it('should set only session if application user is not found', async () => {
+    const mockSession = makeMockSession({ updatedAtMsAgo: 30 * 60 * 1000 });
     (auth.api.getSession as any).mockResolvedValue(mockSession);
     (getUserByEmail as any).mockResolvedValue({ ok: false, error: { message: 'Not found' } });
+    mockContext.req.header.mockReturnValue(undefined);
 
     await authenticate(mockContext, next);
 

--- a/src/middlewares/authenticate.ts
+++ b/src/middlewares/authenticate.ts
@@ -1,10 +1,20 @@
 import type { Context, Next } from 'hono';
 
+import { eq } from 'drizzle-orm';
+import { HTTPException } from 'hono/http-exception';
+
 import type { AppBindings } from '@/lib/types';
 
+import { db } from '@/db';
+import * as schema from '@/db/schema';
 import { getUserByEmail } from '@/domains/users/users.service';
 import { auth } from '@/lib/auth';
 import { logger } from '@/lib/logger';
+
+const MOBILE_ROLLING_DAYS = 60;
+const MOBILE_ROLLING_MS = MOBILE_ROLLING_DAYS * 24 * 60 * 60 * 1000;
+const MOBILE_ROLL_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000; // Roll when < 30 days remain
+const MOBILE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // Check at most once per 24h
 
 /**
  * Authentication Middleware
@@ -12,6 +22,16 @@ import { logger } from '@/lib/logger';
  * Validates the session via BetterAuth and populates the context with:
  * - 'session': The BetterAuth session object
  * - 'user': The application user record linked via email
+ *
+ * Granular Bearer token errors:
+ * - Throws 401 "Invalid or revoked session token" if the token is not in DB.
+ * - Throws 401 "Session token has expired" if the token exists but is expired.
+ * - Only activates when an Authorization: Bearer header is present AND getSession() returns null.
+ *   This preserves the passive middleware behaviour for all other routes.
+ *
+ * Mobile session rolling:
+ * - If the session is flagged isMobile, checks once per 24h (using updatedAt as proxy).
+ * - If remaining lifetime < 30 days, extends expiresAt by 60 days.
  */
 export async function authenticate(c: Context<AppBindings>, next: Next) {
   // Skip auth routes to avoid circularity if applied globally
@@ -19,16 +39,85 @@ export async function authenticate(c: Context<AppBindings>, next: Next) {
     return next();
   }
 
+  const authHeader = c.req.header('Authorization');
+  const hasBearerToken = typeof authHeader === 'string' && authHeader.startsWith('Bearer ');
+
   try {
     const session = await auth.api.getSession({
       headers: c.req.raw.headers,
     });
 
     if (!session) {
+      // Only throw specific errors when a Bearer token was explicitly supplied.
+      // Requests without a token (e.g. public routes) pass through silently.
+      if (hasBearerToken) {
+        const token = authHeader.slice(7).trim();
+
+        const [row] = await db
+          .select({
+            expiresAt: schema.authSession.expiresAt,
+          })
+          .from(schema.authSession)
+          .where(eq(schema.authSession.token, token))
+          .limit(1);
+
+        if (!row) {
+          throw new HTTPException(401, { message: 'Invalid or revoked session token' });
+        }
+
+        if (new Date(row.expiresAt) < new Date()) {
+          throw new HTTPException(401, { message: 'Session token has expired' });
+        }
+
+        // Token is in DB and not expired, but getSession was rejected (revoked / invalid user)
+        throw new HTTPException(401, { message: 'Invalid or revoked session token' });
+      }
+
       return next();
     }
 
     c.set('session', session as any);
+
+    // ── Mobile session rolling (24h-throttled) ──────────────────────────────
+    // Only incur a DB read/write for mobile sessions, and only once per 24h.
+    const rawSession = session.session as unknown as {
+      id: string;
+      updatedAt: Date | string;
+      expiresAt: Date | string;
+      isMobile?: boolean;
+    };
+
+    const updatedAt = new Date(rawSession.updatedAt);
+    const staleCheck = Date.now() - updatedAt.getTime() > MOBILE_CHECK_INTERVAL_MS;
+
+    if (staleCheck) {
+      // One DB read — only executes at most once per 24h per mobile session
+      const [dbSession] = await db
+        .select({
+          isMobile: schema.authSession.isMobile,
+          expiresAt: schema.authSession.expiresAt,
+        })
+        .from(schema.authSession)
+        .where(eq(schema.authSession.id, rawSession.id))
+        .limit(1);
+
+      if (dbSession?.isMobile) {
+        const remainingMs = new Date(dbSession.expiresAt).getTime() - Date.now();
+        if (remainingMs < MOBILE_ROLL_THRESHOLD_MS) {
+          const newExpiry = new Date(Date.now() + MOBILE_ROLLING_MS);
+          const now = new Date();
+          await db
+            .update(schema.authSession)
+            .set({ expiresAt: newExpiry, updatedAt: now })
+            .where(eq(schema.authSession.id, rawSession.id));
+
+          logger.debug('Mobile session rolled: extended by 60 days', {
+            sessionId: rawSession.id,
+          });
+        }
+      }
+    }
+    // ───────────────────────────────────────────────────────────────────────
 
     // Look up the application user
     const userResult = await getUserByEmail(session.user.email);
@@ -40,6 +129,7 @@ export async function authenticate(c: Context<AppBindings>, next: Next) {
       });
     }
   } catch (error) {
+    if (error instanceof HTTPException) throw error;
     logger.error('Authentication middleware error', { error });
   }
 

--- a/src/routes/auth-doc.route.ts
+++ b/src/routes/auth-doc.route.ts
@@ -65,7 +65,6 @@ server.openapi(signInRoute, async (c) => {
 });
 
 // ─── POST /api/auth/forget-password ──────────────────────────────────────────
-// Calls auth.api.requestPasswordReset internally (verified BetterAuth API name).
 const forgetPasswordRoute = createRoute({
   tags: ['Authentication'],
   method: 'post',

--- a/src/routes/auth-doc.route.ts
+++ b/src/routes/auth-doc.route.ts
@@ -63,3 +63,56 @@ server.openapi(signInRoute, async (c) => {
   // in server.ts is registered first and will handle the request.
   return c.json({} as any, HttpStatusCodes.OK);
 });
+
+// ─── POST /api/auth/forget-password ──────────────────────────────────────────
+// Calls auth.api.requestPasswordReset internally (verified BetterAuth API name).
+const forgetPasswordRoute = createRoute({
+  tags: ['Authentication'],
+  method: 'post',
+  path: '/api/auth/forget-password',
+  request: {
+    body: jsonContent(
+      z.object({
+        email: z.string().email().openapi({ example: 'user@example.com' }),
+      }),
+      'Email address to send reset link to'
+    ),
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      z.object({ message: z.string() }),
+      'Password reset email sent'
+    ),
+    [HttpStatusCodes.BAD_REQUEST]: jsonContent(
+      createMessageObjectSchema('Bad Request'),
+      'Invalid email or request failed'
+    ),
+  },
+  summary: 'Request Password Reset',
+  description:
+    'Sends a password reset email to the provided address. Works with Bearer token authentication for mobile clients.',
+});
+
+server.openapi(forgetPasswordRoute, async (c) => {
+  return c.json({ message: 'Password reset email sent' }, HttpStatusCodes.OK);
+});
+
+// ─── POST /api/auth/sign-out ──────────────────────────────────────────────────
+const signOutRoute = createRoute({
+  tags: ['Authentication'],
+  method: 'post',
+  path: '/api/auth/sign-out',
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      z.object({ success: z.boolean() }),
+      'Successfully signed out'
+    ),
+  },
+  summary: 'Sign Out',
+  description:
+    'Invalidates the current session. Accepts both cookie-based sessions and Bearer token authentication for mobile clients.',
+});
+
+server.openapi(signOutRoute, async (c) => {
+  return c.json({ success: true }, HttpStatusCodes.OK);
+});

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -8,11 +8,9 @@ import { server } from './server';
 
 vi.mock('@/lib/auth', () => ({
   auth: {
+    // auth.api.getSession is used by the authenticate middleware — keep it available.
     api: {
-      requestPasswordReset: vi.fn(),
-      signOut: vi.fn(),
       getSession: vi.fn(),
-      setPassword: vi.fn(),
     },
     handler: vi.fn(),
   },
@@ -37,36 +35,43 @@ describe('server Route Handlers', () => {
     vi.clearAllMocks();
   });
 
-  describe('pOST /api/auth/forget-password', () => {
-    it('should call auth.api.requestPasswordReset with body and headers', async () => {
-      const mockResult = { success: true };
-      (auth.api.requestPasswordReset as any).mockResolvedValue(mockResult);
+  // ─── POST /api/auth/forget-password ──────────────────────────────────────
 
-      const requestBody = { email: 'test@example.com' };
+  describe('pOST /api/auth/forget-password', () => {
+    it('should proxy to auth.handler with path rewritten to /api/auth/request-password-reset', async () => {
+      const mockResult = { success: true };
+      (auth.handler as any).mockResolvedValue(
+        new Response(JSON.stringify(mockResult), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
       const res = await server.request('/api/auth/forget-password', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'x-client-type': 'mobile',
         },
-        body: JSON.stringify(requestBody),
+        body: JSON.stringify({ email: 'test@example.com' }),
       });
 
       expect(res.status).toBe(200);
-      const json = await res.json();
-      expect(json).toEqual(mockResult);
+      expect(auth.handler).toHaveBeenCalledOnce();
 
-      expect(auth.api.requestPasswordReset).toHaveBeenCalledWith({
-        body: requestBody,
-        headers: expect.any(Headers),
-      });
+      // Verify the request was rewritten to the BetterAuth-native path so
+      // rate limiting and other middleware in auth.handler are applied.
+      const proxiedRequest: Request = (auth.handler as any).mock.calls[0][0];
+      expect(new URL(proxiedRequest.url).pathname).toBe('/api/auth/request-password-reset');
 
-      const passedHeaders = (auth.api.requestPasswordReset as any).mock.calls[0][0].headers;
-      expect(passedHeaders.get('x-client-type')).toBe('mobile');
+      // Original headers (including custom ones) must be forwarded.
+      expect(proxiedRequest.headers.get('x-client-type')).toBe('mobile');
     });
 
-    it('should return 400 if auth.api.requestPasswordReset throws', async () => {
-      (auth.api.requestPasswordReset as any).mockRejectedValue(new Error('BetterAuth Error'));
+    it('should propagate auth.handler error responses as-is', async () => {
+      (auth.handler as any).mockResolvedValue(
+        new Response(JSON.stringify({ message: 'Rate limit exceeded' }), { status: 429 })
+      );
 
       const res = await server.request('/api/auth/forget-password', {
         method: 'POST',
@@ -74,11 +79,40 @@ describe('server Route Handlers', () => {
         body: JSON.stringify({ email: 'test@example.com' }),
       });
 
-      expect(res.status).toBe(400);
-      const json = await res.json();
-      expect(json).toEqual({ message: 'Failed to send password reset email' });
+      expect(res.status).toBe(429);
     });
   });
+
+  // ─── POST /api/auth/password/set ─────────────────────────────────────────
+
+  describe('pOST /api/auth/password/set', () => {
+    it('should proxy to auth.handler with path rewritten to /api/auth/set-password', async () => {
+      (auth.handler as any).mockResolvedValue(
+        new Response(JSON.stringify({ status: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      const res = await server.request('/api/auth/password/set', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+        },
+        body: JSON.stringify({ newPassword: 'hunter2' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(auth.handler).toHaveBeenCalledOnce();
+
+      const proxiedRequest: Request = (auth.handler as any).mock.calls[0][0];
+      expect(new URL(proxiedRequest.url).pathname).toBe('/api/auth/set-password');
+      expect(proxiedRequest.headers.get('Authorization')).toBe('Bearer test-token');
+    });
+  });
+
+  // ─── POST /api/auth/sign-out ──────────────────────────────────────────────
 
   describe('pOST /api/auth/sign-out', () => {
     it('should delegate to auth.handler so Set-Cookie headers are forwarded to the client', async () => {
@@ -97,7 +131,6 @@ describe('server Route Handlers', () => {
       // auth.handler must be called (not auth.api.signOut) so BetterAuth can
       // return the full response including the Set-Cookie header for web clients.
       expect(auth.handler).toHaveBeenCalled();
-      expect(auth.api.signOut).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { auth } from '@/lib/auth';
+
+import { server } from './server';
+
+// ─── Module Mocks ────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/auth', () => ({
+  auth: {
+    api: {
+      requestPasswordReset: vi.fn(),
+      signOut: vi.fn(),
+      getSession: vi.fn(),
+      setPassword: vi.fn(),
+    },
+    handler: vi.fn(),
+  },
+}));
+
+vi.mock('@/db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('server Route Handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('pOST /api/auth/forget-password', () => {
+    it('should call auth.api.requestPasswordReset with body and headers', async () => {
+      const mockResult = { success: true };
+      (auth.api.requestPasswordReset as any).mockResolvedValue(mockResult);
+
+      const requestBody = { email: 'test@example.com' };
+      const res = await server.request('/api/auth/forget-password', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-client-type': 'mobile',
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toEqual(mockResult);
+
+      expect(auth.api.requestPasswordReset).toHaveBeenCalledWith({
+        body: requestBody,
+        headers: expect.any(Headers),
+      });
+
+      const passedHeaders = (auth.api.requestPasswordReset as any).mock.calls[0][0].headers;
+      expect(passedHeaders.get('x-client-type')).toBe('mobile');
+    });
+
+    it('should return 400 if auth.api.requestPasswordReset throws', async () => {
+      (auth.api.requestPasswordReset as any).mockRejectedValue(new Error('BetterAuth Error'));
+
+      const res = await server.request('/api/auth/forget-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'test@example.com' }),
+      });
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json).toEqual({ message: 'Failed to send password reset email' });
+    });
+  });
+
+  describe('pOST /api/auth/sign-out', () => {
+    it('should delegate to auth.handler so Set-Cookie headers are forwarded to the client', async () => {
+      (auth.handler as any).mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), { status: 200 })
+      );
+
+      const res = await server.request('/api/auth/sign-out', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer token-123',
+        },
+      });
+
+      expect(res.status).toBe(200);
+      // auth.handler must be called (not auth.api.signOut) so BetterAuth can
+      // return the full response including the Set-Cookie header for web clients.
+      expect(auth.handler).toHaveBeenCalled();
+      expect(auth.api.signOut).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -55,6 +55,9 @@ export function createServer() {
         return null;
       },
       credentials: true,
+      // Expose set-auth-token so clients can read the Bearer token from the
+      // BetterAuth bearer() plugin response header after sign-in.
+      exposeHeaders: ['set-auth-token'],
     })
   );
 
@@ -71,7 +74,9 @@ export function createServer() {
         'Access-Control-Allow-Origin': origin,
         'Access-Control-Allow-Credentials': 'true',
         'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-better-auth-*',
+        'Access-Control-Allow-Headers':
+          'Content-Type, Authorization, x-client-type, x-better-auth-*',
+        'Access-Control-Expose-Headers': 'set-auth-token',
         'Access-Control-Max-Age': '86400',
       },
     });
@@ -86,7 +91,7 @@ export function createServer() {
       });
       return c.json(result);
     } catch (err) {
-      console.error('Password set error:', err);
+      logger.error('Password set error', { error: err });
       return c.json({ error: { message: 'Unauthorized or invalid request' } }, 401);
     }
   });
@@ -123,6 +128,26 @@ export function createServer() {
       logger.error('Failed to validate verification token', { error: err });
       return c.json({ isValid: false, message: 'Failed to validate token' }, 500);
     }
+  });
+
+  // POST /api/auth/forget-password
+  app.post('/api/auth/forget-password', async (c) => {
+    try {
+      const body = await c.req.json();
+      const result = await auth.api.requestPasswordReset({
+        body,
+        headers: c.req.raw.headers,
+      });
+      return c.json(result);
+    } catch (err) {
+      logger.error('Forget password error', { error: err });
+      return c.json({ message: 'Failed to send password reset email' }, 400);
+    }
+  });
+
+  // POST /api/auth/sign-out
+  app.post('/api/auth/sign-out', (c) => {
+    return auth.handler(c.req.raw);
   });
 
   app.all('/api/auth/*', (c) => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,3 +1,5 @@
+import type { Context } from 'hono';
+
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { eq } from 'drizzle-orm';
 import { cors } from 'hono/cors';
@@ -82,19 +84,17 @@ export function createServer() {
     });
   });
 
-  app.post('/api/auth/password/set', async (c) => {
-    try {
-      const body = await c.req.json();
-      const result = await auth.api.setPassword({
-        body,
-        headers: c.req.raw.headers,
-      });
-      return c.json(result);
-    } catch (err) {
-      logger.error('Password set error', { error: err });
-      return c.json({ error: { message: 'Unauthorized or invalid request' } }, 401);
-    }
-  });
+  // ─── BetterAuth proxy helper ─────────────────────────────────────
+  async function proxyToAuth(c: Context<AppEnv>, betterAuthPath: string): Promise<Response> {
+    const url = new URL(c.req.url);
+    url.pathname = betterAuthPath;
+    return auth.handler(new Request(url, c.req.raw));
+  }
+
+  app.post('/api/auth/password/set', (c) => proxyToAuth(c, '/api/auth/set-password'));
+
+  // POST /api/auth/forget-password
+  app.post('/api/auth/forget-password', (c) => proxyToAuth(c, '/api/auth/request-password-reset'));
 
   app.get('/api/auth/validate-token', async (c) => {
     const token = c.req.query('token');
@@ -127,21 +127,6 @@ export function createServer() {
     } catch (err) {
       logger.error('Failed to validate verification token', { error: err });
       return c.json({ isValid: false, message: 'Failed to validate token' }, 500);
-    }
-  });
-
-  // POST /api/auth/forget-password
-  app.post('/api/auth/forget-password', async (c) => {
-    try {
-      const body = await c.req.json();
-      const result = await auth.api.requestPasswordReset({
-        body,
-        headers: c.req.raw.headers,
-      });
-      return c.json(result);
-    } catch (err) {
-      logger.error('Forget password error', { error: err });
-      return c.json({ message: 'Failed to send password reset email' }, 400);
     }
   });
 


### PR DESCRIPTION
- #165 
- Mobile client identification — Implemented x-client-type / User-Agent header detection on auth endpoints (sign-in, sign-out, forgot password). Sign-in uses these to classify the session as mobile (60-day lifetime, isMobile flag in DB). All other APIs rely solely on the Bearer token.
- Documentation — Full mobile integration guide added to docs/authentication-migration.md covering all of the above with an Axios interceptor example
- Added new test cases as well for the mobile auth scenerios.