### PR TITLE
fix(usfm): stop leaking raw error detail in sync export 500s

### DIFF
--- a/src/domains/usfm/usfm.route.ts
+++ b/src/domains/usfm/usfm.route.ts
@@ -12,11 +12,6 @@ import { server } from '@/server/server';
 
 import * as usfmService from './usfm.service';
 
-interface ErrorResponse {
-  error: string;
-  details?: string;
-}
-
 const projectUnitIdParam = z.object({
   projectUnitId: z.coerce.number().int().positive(),
 });
@@ -182,12 +177,11 @@ server.openapi(getExportableBooksRoute, async (c) => {
       projectUnitId: c.req.param('projectUnitId'),
     });
 
-    const errorResponse: ErrorResponse = {
-      error: 'Failed to get exportable books',
-      details: errorMessage,
-    };
-
-    return c.json(errorResponse, HttpStatusCodes.INTERNAL_SERVER_ERROR);
+    // Detail is logged above; do not leak the raw error message to the client.
+    return c.json(
+      { error: 'Failed to get exportable books' },
+      HttpStatusCodes.INTERNAL_SERVER_ERROR
+    );
   }
 });
 
@@ -281,13 +275,8 @@ server.openapi(exportProjectUSFMRoute, async (c) => {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     logger.error('USFM export error', { error: errorMessage, projectUnitId, bookIds });
 
-    return c.json(
-      {
-        error: 'Failed to export USFM',
-        details: errorMessage,
-      },
-      HttpStatusCodes.INTERNAL_SERVER_ERROR
-    );
+    // Detail is logged above; do not leak the raw error message to the client.
+    return c.json({ error: 'Failed to export USFM' }, HttpStatusCodes.INTERNAL_SERVER_ERROR);
   }
 });
 


### PR DESCRIPTION
Part of #195.

## Summary

The sync USFM export handlers (`exportProjectUSFMRoute` and the exportable-books
handler) returned the raw exception message to the client via `details`. The
full error is already logged server-side (`logger.error` → App Insights with
`projectUnitId`/`bookIds`), so this drops `details` from the client 500
responses and removes the now-unused `ErrorResponse` interface.

## Scope

- **Sync export path only.** The async-pipeline handlers (`/usfm/async`) have the
  same pattern but are left for #196 (async export pipeline hardening), where
  that handler is being reworked anyway.
- Independent of #189 (auth) — touches the handler bodies, not the route/middleware
  definitions; no overlap.

## Companion

The user-facing half of #195 is in **fluent-web**: send `credentials` on the
export request + surface the server message in the export dialog (separate PR).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 80/80 pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for export operations with simplified error responses. Error messages now provide generic information only, without exposing internal system details to users.

* **Refactor**
  * Removed unused error response helper type to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->