### PR TITLE
feat(usfm): scope export endpoints to the caller's project/org

### DIFF
--- a/src/domains/usfm/usfm-auth.middleware.ts
+++ b/src/domains/usfm/usfm-auth.middleware.ts
@@ -1,0 +1,60 @@
+import { createMiddleware } from 'hono/factory';
+import * as HttpStatusCodes from 'stoker/http-status-codes';
+
+import type { AppEnv } from '@/server/context.types';
+
+import { ProjectPolicy } from '@/domains/projects/project.policy';
+import * as projectService from '@/domains/projects/projects.service';
+import { resolveIsProjectMember } from '@/domains/projects/users/project-users.service';
+
+/**
+ * Ensures the caller may read the project that owns the given project unit, so
+ * USFM export endpoints cannot expose another organization's translated content.
+ * Mirrors the read path in translated-verse-auth.middleware.ts and returns 404
+ * (not 403) on any failure to avoid project-unit enumeration. Requires
+ * authenticateUser to have run first.
+ *
+ * On success, sets `project` and `projectAuthContext` on the context so handlers
+ * can reuse them without re-querying.
+ */
+export function requireProjectUnitAccess(paramName = 'projectUnitId') {
+  return createMiddleware<AppEnv>(async (c, next) => {
+    const user = c.get('user')!;
+    const policyUser = {
+      id: user.id,
+      role: user.role,
+      roleName: user.roleName,
+      organization: user.organization,
+    };
+
+    const projectUnitId = Number(c.req.param(paramName));
+    if (!projectUnitId || Number.isNaN(projectUnitId)) {
+      return c.json({ message: 'Project not found' }, HttpStatusCodes.NOT_FOUND);
+    }
+
+    const unitResult = await projectService.getProjectIdByUnitId(projectUnitId);
+    if (!unitResult.ok) {
+      return c.json({ message: 'Project not found' }, HttpStatusCodes.NOT_FOUND);
+    }
+
+    const projectResult = await projectService.getProjectById(unitResult.data.projectId);
+    if (!projectResult.ok) {
+      return c.json({ message: 'Project not found' }, HttpStatusCodes.NOT_FOUND);
+    }
+
+    const isProjectMember = await resolveIsProjectMember(
+      unitResult.data.projectId,
+      user.id,
+      user.roleName
+    );
+
+    if (!ProjectPolicy.read(policyUser, projectResult.data, isProjectMember)) {
+      return c.json({ message: 'Project not found' }, HttpStatusCodes.NOT_FOUND);
+    }
+
+    c.set('project', projectResult.data);
+    c.set('projectAuthContext', { isProjectMember });
+
+    return next();
+  });
+}

--- a/src/domains/usfm/usfm.route.ts
+++ b/src/domains/usfm/usfm.route.ts
@@ -12,6 +12,7 @@ import { getQueue, QUEUE_NAMES } from '@/lib/queue';
 import { authenticateUser } from '@/middlewares/role-auth';
 import { server } from '@/server/server';
 
+import { requireProjectUnitAccess } from './usfm-auth.middleware';
 import * as usfmService from './usfm.service';
 
 interface ErrorResponse {
@@ -70,12 +71,16 @@ const getExportableBooksRoute = createRoute({
   tags: ['USFM Export'],
   method: 'get',
   path: '/project-units/{projectUnitId}/usfm/books',
-  middleware: [authenticateUser] as const,
+  middleware: [authenticateUser, requireProjectUnitAccess()] as const,
   request: {
     params: projectUnitIdParam,
   },
   responses: {
     [HttpStatusCodes.OK]: jsonContent(exportableBooksResponseSchema, 'List of exportable books'),
+    [HttpStatusCodes.NOT_FOUND]: jsonContent(
+      createMessageObjectSchema('Project not found'),
+      'Project not found'
+    ),
     [HttpStatusCodes.UNAUTHORIZED]: jsonContent(
       createMessageObjectSchema('Unauthorized'),
       'Authentication required'
@@ -92,7 +97,7 @@ const exportProjectUSFMRoute = createRoute({
   tags: ['USFM Export'],
   method: 'post',
   path: '/project-units/{projectUnitId}/usfm',
-  middleware: [authenticateUser] as const,
+  middleware: [authenticateUser, requireProjectUnitAccess()] as const,
   request: {
     params: projectUnitIdParam,
     body: jsonContent(exportRequestBodySchema, 'Book selection for export'),
@@ -106,7 +111,10 @@ const exportProjectUSFMRoute = createRoute({
         },
       },
     },
-    [HttpStatusCodes.NOT_FOUND]: jsonContent(errorSchema, 'Project not found'),
+    [HttpStatusCodes.NOT_FOUND]: jsonContent(
+      createMessageObjectSchema('Project not found'),
+      'Project not found'
+    ),
     [HttpStatusCodes.BAD_REQUEST]: jsonContent(errorSchema, 'Bad request'),
     [HttpStatusCodes.UNAUTHORIZED]: jsonContent(
       createMessageObjectSchema('Unauthorized'),
@@ -124,13 +132,17 @@ const exportProjectUSFMAsyncRoute = createRoute({
   tags: ['USFM Export'],
   method: 'post',
   path: '/project-units/{projectUnitId}/usfm/async',
-  middleware: [authenticateUser] as const,
+  middleware: [authenticateUser, requireProjectUnitAccess()] as const,
   request: {
     params: projectUnitIdParam,
     body: jsonContent(exportRequestBodySchema, 'Book selection for export'),
   },
   responses: {
     [HttpStatusCodes.ACCEPTED]: jsonContent(exportAsyncResponseSchema, 'Export job queued'),
+    [HttpStatusCodes.NOT_FOUND]: jsonContent(
+      createMessageObjectSchema('Project not found'),
+      'Project not found'
+    ),
     [HttpStatusCodes.BAD_REQUEST]: jsonContent(errorSchema, 'Bad request'),
     [HttpStatusCodes.UNAUTHORIZED]: jsonContent(
       createMessageObjectSchema('Unauthorized'),
@@ -259,16 +271,9 @@ server.openapi(exportProjectUSFMRoute, async (c) => {
       }
     }
 
-    const projectNameResult = await usfmService.getProjectName(projectUnitId);
-    if (!projectNameResult.ok || !projectNameResult.data) {
-      logger.warn('Project not found for project unit', { projectUnitId });
-      return c.json(
-        { error: 'Project not found for this project unit' },
-        HttpStatusCodes.NOT_FOUND
-      );
-    }
-
-    const projectName = projectNameResult.data;
+    // Project access (and existence) is already verified by requireProjectUnitAccess,
+    // which puts the resolved project on the context.
+    const projectName = c.get('project')!.name;
 
     const exportResultObj = await usfmService.createUSFMZipStreamAsync(projectUnitId, bookIds);
     if (!exportResultObj.ok || !exportResultObj.data) {


### PR DESCRIPTION
Closes #198.

> **Stacked on #189** — base is the `fix/require-auth-bibles-usfm` branch (this builds on the `authenticateUser` middleware #189 adds to the USFM routes). Retarget to `main` once #189 merges.

## Summary

After #189 the USFM routes require authentication but perform no project/org check — the export pulls per-project translated content (`usfm.service.ts` `getProjectBooks` + `getBookVerses`), so any logged-in user from another org could export a project they don't belong to by guessing a `projectUnitId`.

- New `requireProjectUnitAccess` middleware (`usfm-auth.middleware.ts`): resolves `projectUnitId` → project → org and applies `ProjectPolicy.read`, mirroring `translated-verse-auth.middleware.ts`. Returns **404** (not 403) on denial to avoid project-unit enumeration, and stashes the resolved project on the context.
- Applied to the three `/project-units/{projectUnitId}/usfm*` routes (books, sync export, async export). `/jobs` and `/downloads` are async-only — owner-binding is tracked in #196.
- Each route's 404 is documented as `{ message }` (`createMessageObjectSchema`), matching what the middleware/global handler returns.
- Sync handler reads the project name from the context instead of re-querying via `getProjectName`, removing a redundant query and a duplicate `{ error }` 404.

## Behaviour

| Caller | Before | After |
|---|---|---|
| Member / same-org manager | export | export |
| Logged-in user, different org | **export** ❌ | 404 |
| Unauthenticated | 401 (from #189) | 401 |

## Testing note

Mirrors the existing record-level auth middlewares (translated-verse-auth, project-auth), which aren't unit-tested in this repo, so no new test file — the logic is identical to the proven translated-verses read path.

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 80/80 pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced access control verification for USFM export operations
  * Streamlined project data retrieval for export endpoints
  * Standardized error response messages for unavailable projects across USFM endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->