### PR TITLE
fix(presence): require chapter-assignment participation on presence routes

### DIFF
--- a/src/domains/chapter-assignments/presence/chapter-assignments-presence.route.ts
+++ b/src/domains/chapter-assignments/presence/chapter-assignments-presence.route.ts
@@ -4,6 +4,8 @@ import * as HttpStatusPhrases from 'stoker/http-status-phrases';
 import { jsonContent } from 'stoker/openapi/helpers';
 import { createMessageObjectSchema } from 'stoker/openapi/schemas';
 
+import { requireChapterAssignmentAccess } from '@/domains/chapter-assignments/chapter-assignment-auth.middleware';
+import { CHAPTER_ASSIGNMENT_ACTIONS } from '@/domains/chapter-assignments/chapter-assignments.types';
 import { PERMISSIONS } from '@/lib/permissions';
 import { getHttpStatus } from '@/lib/types';
 import { authenticateUser, requirePermission } from '@/middlewares/role-auth';
@@ -28,13 +30,25 @@ const registerPresenceRoute = createRoute({
   tags: ['Chapter Assignments - Presence'],
   method: 'post',
   path: '/chapter-assignments/{chapterAssignmentId}/presence',
-  middleware: [authenticateUser, requirePermission(PERMISSIONS.CONTENT_UPDATE)] as const,
+  middleware: [
+    authenticateUser,
+    requirePermission(PERMISSIONS.CONTENT_UPDATE),
+    requireChapterAssignmentAccess(CHAPTER_ASSIGNMENT_ACTIONS.IS_PARTICIPANT),
+  ] as const,
   request: { params: chapterAssignmentIdParam },
   responses: {
     [HttpStatusCodes.OK]: jsonContent(presenceResponseSchema, 'Presence registered successfully'),
     [HttpStatusCodes.UNAUTHORIZED]: jsonContent(
       createMessageObjectSchema('Unauthorized'),
       'Authentication required'
+    ),
+    [HttpStatusCodes.FORBIDDEN]: jsonContent(
+      createMessageObjectSchema('Forbidden'),
+      'Access denied'
+    ),
+    [HttpStatusCodes.NOT_FOUND]: jsonContent(
+      createMessageObjectSchema(HttpStatusPhrases.NOT_FOUND),
+      'Chapter assignment not found'
     ),
     [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
       createMessageObjectSchema(HttpStatusPhrases.INTERNAL_SERVER_ERROR),
@@ -50,13 +64,25 @@ const removePresenceRoute = createRoute({
   tags: ['Chapter Assignments - Presence'],
   method: 'delete',
   path: '/chapter-assignments/{chapterAssignmentId}/presence',
-  middleware: [authenticateUser, requirePermission(PERMISSIONS.CONTENT_UPDATE)] as const,
+  middleware: [
+    authenticateUser,
+    requirePermission(PERMISSIONS.CONTENT_UPDATE),
+    requireChapterAssignmentAccess(CHAPTER_ASSIGNMENT_ACTIONS.IS_PARTICIPANT),
+  ] as const,
   request: { params: chapterAssignmentIdParam },
   responses: {
     [HttpStatusCodes.NO_CONTENT]: { description: 'Presence removed successfully' },
     [HttpStatusCodes.UNAUTHORIZED]: jsonContent(
       createMessageObjectSchema('Unauthorized'),
       'Authentication required'
+    ),
+    [HttpStatusCodes.FORBIDDEN]: jsonContent(
+      createMessageObjectSchema('Forbidden'),
+      'Access denied'
+    ),
+    [HttpStatusCodes.NOT_FOUND]: jsonContent(
+      createMessageObjectSchema(HttpStatusPhrases.NOT_FOUND),
+      'Chapter assignment not found'
     ),
     [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
       createMessageObjectSchema(HttpStatusPhrases.INTERNAL_SERVER_ERROR),


### PR DESCRIPTION
Part of #197 (the presence-route authz item).

## Summary

The `POST`/`DELETE /chapter-assignments/{chapterAssignmentId}/presence` routes were gated only by `authenticateUser` + `requirePermission(CONTENT_UPDATE)`, with no record-level check — so any translator could register presence on, and read concurrent-editor info for, **any** `chapterAssignmentId`, leaking who's editing what across assignments.

- Add `requireChapterAssignmentAccess(CHAPTER_ASSIGNMENT_ACTIONS.IS_PARTICIPANT)` to both routes, matching the sibling editor-state routes.
- Document the resulting `403`/`404` responses (the `403` from `requirePermission` was previously undocumented too).

Returns 404 (not 403) on non-participation, consistent with the middleware's anti-enumeration behaviour.

## Scope

This covers the **authz** item of #197. The other two items — QA that the 2nd-editor warning fires, and the first-editor race in `upsertAndQueryFirstEditor` (only if QA shows flakiness) — need a running 2-user environment, so they stay open on #197.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 80/80 pass
- [ ] Manual: a translator who is neither drafter nor peer-checker of a chapter gets 404 from its `/presence` routes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Updates**
  * Strengthened access control for chapter assignment presence operations. Users can now only register or remove their presence in chapter assignments where they are designated participants, ensuring proper authorization across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->